### PR TITLE
enable collections through parent inscriptions method #783

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -18,7 +18,7 @@ use {
   std::sync::atomic::{self, AtomicBool},
 };
 
-mod entry;
+pub(crate) mod entry;
 mod fetcher;
 mod rtx;
 mod updater;

--- a/src/index.rs
+++ b/src/index.rs
@@ -23,7 +23,7 @@ mod fetcher;
 mod rtx;
 mod updater;
 
-const SCHEMA_VERSION: u64 = 3;
+const SCHEMA_VERSION: u64 = 4;
 
 macro_rules! define_table {
   ($name:ident, $key:ty, $value:ty) => {
@@ -33,6 +33,7 @@ macro_rules! define_table {
 
 define_table! { HEIGHT_TO_BLOCK_HASH, u64, &BlockHashValue }
 define_table! { INSCRIPTION_ID_TO_INSCRIPTION_ENTRY, &InscriptionIdValue, InscriptionEntryValue }
+define_table! { INSCRIPTION_ID_TO_PARENT_ID, &InscriptionIdValue, &InscriptionIdValue }
 define_table! { INSCRIPTION_ID_TO_SATPOINT, &InscriptionIdValue, &SatPointValue }
 define_table! { INSCRIPTION_NUMBER_TO_INSCRIPTION_ID, u64, &InscriptionIdValue }
 define_table! { OUTPOINT_TO_SAT_RANGES, &OutPointValue, &[u8] }
@@ -204,6 +205,7 @@ impl Index {
 
         tx.open_table(HEIGHT_TO_BLOCK_HASH)?;
         tx.open_table(INSCRIPTION_ID_TO_INSCRIPTION_ENTRY)?;
+        tx.open_table(INSCRIPTION_ID_TO_PARENT_ID)?;
         tx.open_table(INSCRIPTION_ID_TO_SATPOINT)?;
         tx.open_table(INSCRIPTION_NUMBER_TO_INSCRIPTION_ID)?;
         tx.open_table(OUTPOINT_TO_VALUE)?;

--- a/src/index/entry.rs
+++ b/src/index/entry.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub(super) trait Entry: Sized {
+pub(crate) trait Entry: Sized {
   type Value;
 
   fn load(value: Self::Value) -> Self;

--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -404,6 +404,7 @@ impl Updater {
 
     let mut inscription_id_to_inscription_entry =
       wtx.open_table(INSCRIPTION_ID_TO_INSCRIPTION_ENTRY)?;
+    let mut inscription_id_to_parent_id = wtx.open_table(INSCRIPTION_ID_TO_PARENT_ID)?;
     let mut inscription_id_to_satpoint = wtx.open_table(INSCRIPTION_ID_TO_SATPOINT)?;
     let mut inscription_number_to_inscription_id =
       wtx.open_table(INSCRIPTION_NUMBER_TO_INSCRIPTION_ID)?;
@@ -421,6 +422,7 @@ impl Updater {
       &mut inscription_id_to_satpoint,
       value_receiver,
       &mut inscription_id_to_inscription_entry,
+      &mut inscription_id_to_parent_id,
       lost_sats,
       &mut inscription_number_to_inscription_id,
       &mut outpoint_to_value,
@@ -519,6 +521,7 @@ impl Updater {
         outpoint_to_sat_ranges.insert(&OutPoint::null().store(), lost_sat_ranges.as_slice())?;
       }
     } else {
+      // move coinbase to end
       for (tx, txid) in block.txdata.iter().skip(1).chain(block.txdata.first()) {
         lost_sats += inscription_updater.index_transaction_inscriptions(tx, *txid, None)?;
       }

--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -7,7 +7,9 @@ pub(super) struct Flotsam {
   parent: Option<InscriptionId>,
 }
 
+// change name to Jetsam or more poetic german word
 enum Origin {
+  // put Some(parent_id) in Origin::New() 
   New(u64),
   Old(SatPoint),
 }

--- a/src/inscription.rs
+++ b/src/inscription.rs
@@ -65,7 +65,7 @@ impl Inscription {
     let content_type = Media::content_type_for_path(path)?;
 
     let parent = if let Some(inscription_id) = parent {
-      Some(inscription_id.to_string().into_bytes())
+      Some(inscription_id.store())
     } else {
       None
     };

--- a/src/inscription.rs
+++ b/src/inscription.rs
@@ -137,7 +137,7 @@ impl Inscription {
 
   pub(crate) fn get_parent_id(&self) -> Option<InscriptionId> {
     if let Some(vec) = &self.parent {
-      InscriptionId::from_str(str::from_utf8(&vec).unwrap()).ok()
+      InscriptionId::load(todo!())
     } else {
       None
     }

--- a/src/inscription.rs
+++ b/src/inscription.rs
@@ -1,5 +1,6 @@
 use {
   super::*,
+  crate::index::entry::Entry,
   bitcoin::{
     blockdata::{
       opcodes,
@@ -64,14 +65,8 @@ impl Inscription {
 
     let content_type = Media::content_type_for_path(path)?;
 
-    let parent = if let Some(inscription_id) = parent {
-      Some(inscription_id.store())
-    } else {
-      None
-    };
-
     Ok(Self {
-      parent,
+      parent: parent.store(),
       body: Some(body),
       content_type: Some(content_type.into()),
     })
@@ -137,7 +132,9 @@ impl Inscription {
 
   pub(crate) fn get_parent_id(&self) -> Option<InscriptionId> {
     if let Some(vec) = &self.parent {
-      InscriptionId::load(todo!())
+      Some(InscriptionId::load(
+        vec.clone().try_into().expect("expected a [u8; 36]"),
+      ))
     } else {
       None
     }

--- a/src/subcommand/preview.rs
+++ b/src/subcommand/preview.rs
@@ -86,6 +86,7 @@ impl Preview {
             dry_run: false,
             no_limit: false,
             destination: None,
+            parent: None,
           },
         )),
       }

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1971,6 +1971,7 @@ mod tests {
   fn content_response_no_content() {
     assert_eq!(
       Server::content_response(Inscription::new(
+        None,
         Some("text/plain".as_bytes().to_vec()),
         None
       )),
@@ -1981,6 +1982,7 @@ mod tests {
   #[test]
   fn content_response_with_content() {
     let (headers, body) = Server::content_response(Inscription::new(
+      None,
       Some("text/plain".as_bytes().to_vec()),
       Some(vec![1, 2, 3]),
     ))
@@ -1993,7 +1995,7 @@ mod tests {
   #[test]
   fn content_response_no_content_type() {
     let (headers, body) =
-      Server::content_response(Inscription::new(None, Some(Vec::new()))).unwrap();
+      Server::content_response(Inscription::new(None, None, Some(Vec::new()))).unwrap();
 
     assert_eq!(headers["content-type"], "application/octet-stream");
     assert!(body.is_empty());
@@ -2291,7 +2293,7 @@ mod tests {
 
     let txid = server.bitcoin_rpc_server.broadcast_tx(TransactionTemplate {
       inputs: &[(1, 0, 0)],
-      witness: Inscription::new(Some("foo/bar".as_bytes().to_vec()), None).to_witness(),
+      witness: Inscription::new(None, Some("foo/bar".as_bytes().to_vec()), None).to_witness(),
       ..Default::default()
     });
 
@@ -2313,7 +2315,7 @@ mod tests {
 
     let txid = server.bitcoin_rpc_server.broadcast_tx(TransactionTemplate {
       inputs: &[(1, 0, 0)],
-      witness: Inscription::new(Some("image/png".as_bytes().to_vec()), None).to_witness(),
+      witness: Inscription::new(None, Some("image/png".as_bytes().to_vec()), None).to_witness(),
       ..Default::default()
     });
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -101,7 +101,7 @@ pub(crate) fn tx_out(value: u64, address: Address) -> TxOut {
 }
 
 pub(crate) fn inscription(content_type: &str, body: impl AsRef<[u8]>) -> Inscription {
-  Inscription::new(Some(content_type.into()), Some(body.as_ref().into()))
+  Inscription::new(None, Some(content_type.into()), Some(body.as_ref().into()))
 }
 
 pub(crate) fn inscription_id(n: u32) -> InscriptionId {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -43,6 +43,7 @@ struct Inscribe {
   inscription: String,
   reveal: Txid,
   fees: u64,
+  parent: Option<String>,
 }
 
 fn inscribe(rpc_server: &test_bitcoincore_rpc::Handle) -> Inscribe {

--- a/tests/wallet/inscribe.rs
+++ b/tests/wallet/inscribe.rs
@@ -335,7 +335,7 @@ fn inscribe_with_dry_run_flag() {
 }
 
 #[test]
-fn inscribe_with_dry_run_flag_fees_inscrease() {
+fn inscribe_with_dry_run_flag_fees_increase() {
   let rpc_server = test_bitcoincore_rpc::spawn();
   create_wallet(&rpc_server);
   rpc_server.mine_blocks(1);
@@ -393,4 +393,45 @@ fn inscribe_with_no_limit() {
   CommandBuilder::new("wallet inscribe --no-limit degenerate.png")
     .write("degenerate.png", four_megger)
     .rpc_server(&rpc_server);
+}
+
+#[test]
+fn inscribe_with_parent_inscription() {
+  let rpc_server = test_bitcoincore_rpc::spawn();
+  create_wallet(&rpc_server);
+  rpc_server.mine_blocks(1);
+
+  let parent_id = CommandBuilder::new("wallet inscribe parent.png")
+    .write("parent.png", [1; 520])
+    .rpc_server(&rpc_server)
+    .output::<Inscribe>()
+    .inscription;
+
+  rpc_server.mine_blocks(1);
+
+  assert_eq!(
+    parent_id,
+    CommandBuilder::new(format!("wallet inscribe --parent {parent_id} child.png"))
+      .write("child.png", [1; 520])
+      .rpc_server(&rpc_server)
+      .output::<Inscribe>()
+      .parent
+      .unwrap()
+  );
+}
+
+#[test]
+fn inscribe_with_non_existent_parent_inscription() {
+  let rpc_server = test_bitcoincore_rpc::spawn();
+  create_wallet(&rpc_server);
+  rpc_server.mine_blocks(1);
+
+  let parent_id = "3ac40a8f3c0d295386e1e597467a1ee0578df780834be885cd62337c2ed738a5i0";
+
+  CommandBuilder::new(format!("wallet inscribe --parent {parent_id} child.png"))
+    .write("child.png", [1; 520])
+    .rpc_server(&rpc_server)
+    .expected_stderr(format!("error: specified parent {parent_id} does not exist\n"))
+    .expected_exit_code(1)
+    .run();
 }


### PR DESCRIPTION
Provenance is important for art, and a large part of how it derives its value. We should have some notion of the provenance of an inscription:

1. For an inscription, see who made it
2. For a creator, see which inscriptions they've made
3. Allow referencing an inscription within an artist's body of work by number or name (maybe just name, so they aren't confused with symbols) `/ARTIST_SYMBOL/NUMBER`

This will be accomplished as follows:
- We are introducing the concept of parent-child relationships between inscriptions
- When an inscription is created, it can be made the child of an existing inscription, which becomes its parent
- The UTXO that currently holds the parent inscription is an additional input to the reveal transaction for the child inscription and spent to a separate output
- The parent relationship needs to be established when an inscription is created and cannot be added or changed later
- An inscription can only have one (or no) parent
- If an inscription has a parent, the child's inscription page will link to the parent's inscription page
- If an inscription has been used as a parent inscription, the parent's inscription will contain links to all of its child inscriptions

This concept can be used for provenance (with the parent inscription representing an artist). but it can also be used to establish collections. 

- If an inscription is part of a collection, all inscriptions that are part of the collection should have an inscription representing the collection as their parent.
- The collection inscription could in turn have the inscription representing the artist as its parent. Additional levels can also easily be established, for example to establish groups of collections, or sets in a collection.
- Collections could be made closed-ended by burning the collection inscription.