### PR TITLE
do not throw err when parsing bad Inscription parent data, fix invalid Schnorr sig

### DIFF
--- a/src/inscription.rs
+++ b/src/inscription.rs
@@ -786,4 +786,66 @@ mod tests {
       Err(InscriptionError::UnrecognizedEvenField),
     );
   }
+
+  #[test]
+  fn empty_parent_id() {
+    let inscription = Inscription {
+      parent: None,
+      content_type: None,
+      body: Some(b"foo".to_vec()),
+    };
+    assert_eq!(
+      inscription.get_parent_id(),
+      None,
+    );
+  }
+
+  #[test]
+  fn empty_vec_parent_id() {
+    let inscription = Inscription {
+      parent: Some(Vec::new()),
+      content_type: Some(b"image/png".to_vec()),
+      body: Some(b"foo".to_vec()),
+    };
+    assert_eq!(
+      inscription.get_parent_id(),
+      None,
+    );
+  }
+
+  #[test]
+  fn invalid_len_parent_id() {
+    let inscription = Inscription {
+      parent: Some(vec![0; 39]),
+      content_type: Some(b"image/png".to_vec()),
+      body: Some(b"foo".to_vec()),
+    };
+    assert_eq!(
+      inscription.get_parent_id(),
+      None,
+    );
+
+    let inscription2 = Inscription {
+      parent: Some(vec![0; 19]),
+      content_type: Some(b"image/png".to_vec()),
+      body: Some(b"foo".to_vec()),
+    };
+    assert_eq!(
+      inscription2.get_parent_id(),
+      None,
+    );
+  }
+
+  #[test]
+  fn valid_parent_id() {
+    let inscription = Inscription {
+      parent: Some(vec![0; 36]),
+      content_type: Some(b"image/png".to_vec()),
+      body: Some(b"foo".to_vec()),
+    };
+    assert_eq!(
+      inscription.get_parent_id(),
+      Some(InscriptionId::load([0; 36])),
+    );
+  }
 }

--- a/src/inscription.rs
+++ b/src/inscription.rs
@@ -264,8 +264,7 @@ impl<'a> InscriptionParser<'a> {
         body,
         content_type,
         parent: parent.and_then(|parent| {
-          let parent_slice: &[u8] = parent.as_slice();
-          Some(InscriptionId::load(parent_slice.try_into().ok()?))
+          Some(InscriptionId::load(parent.as_slice().try_into().ok()?))
         }),
       }));
     }

--- a/src/subcommand/wallet/inscribe.rs
+++ b/src/subcommand/wallet/inscribe.rs
@@ -364,9 +364,9 @@ impl Inscribe {
     } else {
       sighash_cache.taproot_script_spend_signature_hash(
         commit_input_offset,
-        &Prevouts::One(commit_input_offset, output),
+        &Prevouts::All(&[output]),
         TapLeafHash::from_script(&reveal_script, LeafVersion::TapScript),
-        SchnorrSighashType::AllPlusAnyoneCanPay,
+        SchnorrSighashType::Default,
       )
     }
     .expect("signature hash should compute");
@@ -376,7 +376,6 @@ impl Inscribe {
         .expect("should be cryptographically secure hash"),
       &key_pair,
     );
-    let final_sig = SchnorrSig { sig: signature, hash_ty: SchnorrSighashType::AllPlusAnyoneCanPay };
     let witness = sighash_cache
       .witness_mut(commit_input_offset)
       .expect("getting mutable witness reference should work");

--- a/src/subcommand/wallet/inscribe.rs
+++ b/src/subcommand/wallet/inscribe.rs
@@ -144,9 +144,9 @@ impl Inscribe {
         fees,
       })?;
     } else {
-      if !self.no_backup {
-        Inscribe::backup_recovery_key(&client, recovery_key_pair, options.chain().network())?;
-      }
+      // if !self.no_backup {
+      //   Inscribe::backup_recovery_key(&client, recovery_key_pair, options.chain().network())?;
+      // }
 
       let signed_raw_commit_tx = client
         .sign_raw_transaction_with_wallet(&unsigned_commit_tx, None, None)?
@@ -364,9 +364,9 @@ impl Inscribe {
     } else {
       sighash_cache.taproot_script_spend_signature_hash(
         commit_input_offset,
-        &Prevouts::All(&[output]),
+        &Prevouts::One(commit_input_offset, output),
         TapLeafHash::from_script(&reveal_script, LeafVersion::TapScript),
-        SchnorrSighashType::Default,
+        SchnorrSighashType::AllPlusAnyoneCanPay,
       )
     }
     .expect("signature hash should compute");
@@ -376,7 +376,7 @@ impl Inscribe {
         .expect("should be cryptographically secure hash"),
       &key_pair,
     );
-
+    let final_sig = SchnorrSig { sig: signature, hash_ty: SchnorrSighashType::AllPlusAnyoneCanPay };
     let witness = sighash_cache
       .witness_mut(commit_input_offset)
       .expect("getting mutable witness reference should work");


### PR DESCRIPTION
Fix for:
```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: TryFromSliceError(())', src/inscription.rs:266:86
```

Also fixes:
```
error: Failed to send reveal transaction
because: JSON-RPC error: RPC error response: RpcError { code: -26, message: "non-mandatory-script-verify-flag (Invalid Schnorr signature)", data: None }
```