### PR TITLE
Implement child pointer redirection

### DIFF
--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1,4 +1,4 @@
-use serde_json::{Value};
+use serde_json::Value;
 
 use {
   self::{
@@ -870,15 +870,11 @@ impl Server {
 
   fn get_url_params_from_json_value(json: Value) -> String {
     let mut params_str = String::new();
+
     if let Some(url_params_field) = json.get("url_params") {
       if let Some(url_params) = url_params_field.as_array() {
-        // do a .join() for url_params
-        for param in url_params {
-          if !params_str.is_empty() {
-            params_str.push('&');
-          }
-          params_str.push_str(&param.as_str().unwrap());
-        }
+        let param_strs: Vec<&str> = url_params.into_iter().map(|v| v.as_str().unwrap()).collect();
+        params_str = param_strs.join("&");
       }
     }
     params_str

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -773,7 +773,7 @@ impl Server {
     let json_result: Result<Value, serde_json::Error> = serde_json::from_slice(&inscription.body().unwrap());
     let json: Value = json_result.unwrap();
 
-    if !json.as_object().unwrap().contains_key("is_pointer") {
+    if !json.as_object().unwrap().contains_key("is_ord_pointer") {
       return None;
     }
 
@@ -786,7 +786,7 @@ impl Server {
     let parent_url_params = Self::get_parent_url_params_if_child_pointer(inscription);
     if let Some(url_params) = parent_url_params {
       let redirect_uri = format!("/content/{}?{}", inscription.get_parent_id().unwrap(), url_params);
-      return Some(Ok(Redirect::temporary(&redirect_uri).into_response()));
+      return Some(Ok(Redirect::permanent(&redirect_uri).into_response()));
     }
     None
   }
@@ -795,7 +795,7 @@ impl Server {
     let parent_url_params = Self::get_parent_url_params_if_child_pointer(inscription);
     if let Some(url_params) = parent_url_params {
       let redirect_uri = format!("/preview/{}?{}", inscription.get_parent_id().unwrap(), url_params);
-      return Some(Ok(Redirect::temporary(&redirect_uri).into_response()));
+      return Some(Ok(Redirect::permanent(&redirect_uri).into_response()));
     }
     None
   }
@@ -872,6 +872,7 @@ impl Server {
     let mut params_str = String::new();
     if let Some(url_params_field) = json.get("url_params") {
       if let Some(url_params) = url_params_field.as_array() {
+        // do a .join() for url_params
         for param in url_params {
           if !params_str.is_empty() {
             params_str.push('&');

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -782,10 +782,35 @@ impl Server {
     Some(parent_url_params)
   }
 
+  // TODO: move to utility module or something
+  fn valid_json(data: Option<&[u8]>) -> bool {
+    match data {
+      Some(bytes) => serde_json::from_slice::<Value>(bytes).is_ok(),
+      None => false,
+    }
+  }
+
+  fn get_url_params_from_json_value(json: Value) -> String {
+    let mut params_str = String::new();
+
+    if let Some(url_params_field) = json.get("url_params") {
+      if let Some(url_params) = url_params_field.as_array() {
+        let param_strs: Vec<&str> = url_params.into_iter().map(|v| v.as_str().unwrap()).collect();
+        params_str = param_strs.join("&");
+      }
+    }
+
+    if params_str.is_empty() {
+      return params_str;
+    }
+
+    format!("?{params_str}")
+  }
+
   fn get_content_response_if_child_pointer(inscription: &Inscription) -> Option<ServerResult<Response>> {
     let parent_url_params = Self::get_parent_url_params_if_child_pointer(inscription);
     if let Some(url_params) = parent_url_params {
-      let redirect_uri = format!("/content/{}?{}", inscription.get_parent_id().unwrap(), url_params);
+      let redirect_uri = format!("/content/{}{}", inscription.get_parent_id().unwrap(), url_params);
       return Some(Ok(Redirect::permanent(&redirect_uri).into_response()));
     }
     None
@@ -794,7 +819,7 @@ impl Server {
   fn get_preview_response_if_child_pointer(inscription: &Inscription) -> Option<ServerResult<Response>> {
     let parent_url_params = Self::get_parent_url_params_if_child_pointer(inscription);
     if let Some(url_params) = parent_url_params {
-      let redirect_uri = format!("/preview/{}?{}", inscription.get_parent_id().unwrap(), url_params);
+      let redirect_uri = format!("/preview/{}{}", inscription.get_parent_id().unwrap(), url_params);
       return Some(Ok(Redirect::permanent(&redirect_uri).into_response()));
     }
     None
@@ -859,25 +884,6 @@ impl Server {
       Media::Unknown => Ok(PreviewUnknownHtml.into_response()),
       Media::Video => Ok(PreviewVideoHtml { inscription_id }.into_response()),
     };
-  }
-
-  fn valid_json(data: Option<&[u8]>) -> bool {
-    match data {
-      Some(bytes) => serde_json::from_slice::<Value>(bytes).is_ok(),
-      None => false,
-    }
-  }
-
-  fn get_url_params_from_json_value(json: Value) -> String {
-    let mut params_str = String::new();
-
-    if let Some(url_params_field) = json.get("url_params") {
-      if let Some(url_params) = url_params_field.as_array() {
-        let param_strs: Vec<&str> = url_params.into_iter().map(|v| v.as_str().unwrap()).collect();
-        params_str = param_strs.join("&");
-      }
-    }
-    params_str
   }
 
   async fn inscription(
@@ -1004,6 +1010,12 @@ mod tests {
 
     fn new_with_args(ord_args: &[&str], server_args: &[&str]) -> Self {
       Self::new_server(test_bitcoincore_rpc::spawn(), None, ord_args, server_args)
+    }
+
+    fn new_with_bitcoin_rpc_server(
+      bitcoin_rpc_server: test_bitcoincore_rpc::Handle,
+    ) -> Self {
+      Self::new_server(bitcoin_rpc_server, None, &[], &[])
     }
 
     fn new_with_bitcoin_rpc_server_and_config(
@@ -1149,6 +1161,19 @@ mod tests {
         .unwrap();
 
       assert_eq!(response.status(), StatusCode::SEE_OTHER);
+      assert_eq!(response.headers().get(header::LOCATION).unwrap(), location);
+    }
+
+    fn assert_redirect_permanent(&self, path: &str, location: &str) {
+      let response = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap()
+        .get(self.join_url(path))
+        .send()
+        .unwrap();
+
+      assert_eq!(response.status(), StatusCode::PERMANENT_REDIRECT);
       assert_eq!(response.headers().get(header::LOCATION).unwrap(), location);
     }
 
@@ -2549,6 +2574,174 @@ mod tests {
       format!("/content/{inscription}"),
       StatusCode::OK,
       &fs::read_to_string("templates/preview-unknown.html").unwrap(),
+    );
+  }
+
+  #[test]
+  fn ord_pointer_child_inscription_redirect_to_parent_with_url_params() {
+    let bitcoin_rpc_server = test_bitcoincore_rpc::spawn();
+    bitcoin_rpc_server.mine_blocks(1);
+    let parent_txid = bitcoin_rpc_server.broadcast_tx(TransactionTemplate {
+      inputs: &[(1, 0, 0)],
+      witnesses: vec![inscription("text/plain;charset=utf-8", "hello").to_witness()],
+      ..Default::default()
+    });
+    let parent_inscription = InscriptionId::from(parent_txid);
+
+    bitcoin_rpc_server.mine_blocks(1);
+
+    let child_txid = bitcoin_rpc_server.broadcast_tx(TransactionTemplate {
+      inputs: &[(2, 1, 0), (2, 0, 0)],
+      witnesses: vec![
+        Witness::new(),
+        inscription_with_parent(
+          "application/json",
+          "{\"is_ord_pointer\":1,\"url_params\":[\"tokenID=69\"]}",
+          parent_inscription
+        ).to_witness()
+      ],
+      ..Default::default()
+    });
+    let child_inscription = InscriptionId {
+      txid: child_txid,
+      index: 1,
+    };
+
+    bitcoin_rpc_server.mine_blocks(1);
+
+    let server = TestServer::new_with_bitcoin_rpc_server(bitcoin_rpc_server);
+
+    server.assert_redirect_permanent(
+      &format!("/preview/{child_inscription}"),
+      &format!("/preview/{parent_inscription}?tokenID=69")
+    );
+    server.assert_redirect_permanent(
+      &format!("/content/{child_inscription}"),
+      &format!("/content/{parent_inscription}?tokenID=69")
+    );
+  }
+
+  #[test]
+  fn ord_pointer_child_inscription_redirect_to_parent_without_url_params() {
+    let bitcoin_rpc_server = test_bitcoincore_rpc::spawn();
+    bitcoin_rpc_server.mine_blocks(1);
+    let parent_txid = bitcoin_rpc_server.broadcast_tx(TransactionTemplate {
+      inputs: &[(1, 0, 0)],
+      witnesses: vec![inscription("text/plain;charset=utf-8", "hello").to_witness()],
+      ..Default::default()
+    });
+    let parent_inscription = InscriptionId::from(parent_txid);
+
+    bitcoin_rpc_server.mine_blocks(1);
+
+    let child_txid = bitcoin_rpc_server.broadcast_tx(TransactionTemplate {
+      inputs: &[(2, 1, 0), (2, 0, 0)],
+      witnesses: vec![
+        Witness::new(),
+        inscription_with_parent(
+          "application/json",
+          "{\"is_ord_pointer\":1}",
+          parent_inscription
+        ).to_witness()
+      ],
+      ..Default::default()
+    });
+    let child_inscription = InscriptionId {
+      txid: child_txid,
+      index: 1,
+    };
+
+    bitcoin_rpc_server.mine_blocks(1);
+
+    let server = TestServer::new_with_bitcoin_rpc_server(bitcoin_rpc_server);
+
+    server.assert_redirect_permanent(
+      &format!("/preview/{child_inscription}"),
+      &format!("/preview/{parent_inscription}")
+    );
+    server.assert_redirect_permanent(
+      &format!("/content/{child_inscription}"),
+      &format!("/content/{parent_inscription}")
+    );
+  }
+
+  #[test]
+  fn non_pointer_json_child_inscription_does_not_redirect_to_parent() {
+    let bitcoin_rpc_server = test_bitcoincore_rpc::spawn();
+    bitcoin_rpc_server.mine_blocks(1);
+    let parent_txid = bitcoin_rpc_server.broadcast_tx(TransactionTemplate {
+      inputs: &[(1, 0, 0)],
+      witnesses: vec![inscription("text/plain;charset=utf-8", "hello").to_witness()],
+      ..Default::default()
+    });
+    let parent_inscription = InscriptionId::from(parent_txid);
+
+    bitcoin_rpc_server.mine_blocks(1);
+
+    let child_txid = bitcoin_rpc_server.broadcast_tx(TransactionTemplate {
+      inputs: &[(2, 1, 0), (2, 0, 0)],
+      witnesses: vec![
+        Witness::new(),
+        inscription_with_parent(
+          "application/json",
+          "{\"not_ord_pointer\":1}",
+          parent_inscription
+        ).to_witness()
+      ],
+      ..Default::default()
+    });
+    let child_inscription = InscriptionId {
+      txid: child_txid,
+      index: 1,
+    };
+
+    bitcoin_rpc_server.mine_blocks(1);
+
+    let server = TestServer::new_with_bitcoin_rpc_server(bitcoin_rpc_server);
+
+    server.assert_response_csp(
+      format!("/preview/{}", child_inscription),
+      StatusCode::OK,
+      "default-src 'self'",
+      ".*<pre>\\{&quot;not_ord_pointer&quot;:1\\}</pre>.*",
+    );
+  }
+
+  #[test]
+  fn non_pointer_child_inscription_does_not_redirect_to_parent() {
+    let bitcoin_rpc_server = test_bitcoincore_rpc::spawn();
+    bitcoin_rpc_server.mine_blocks(1);
+    let parent_txid = bitcoin_rpc_server.broadcast_tx(TransactionTemplate {
+      inputs: &[(1, 0, 0)],
+      witnesses: vec![inscription("text/plain;charset=utf-8", "hello").to_witness()],
+      ..Default::default()
+    });
+    let parent_inscription = InscriptionId::from(parent_txid);
+
+    bitcoin_rpc_server.mine_blocks(1);
+
+    let child_txid = bitcoin_rpc_server.broadcast_tx(TransactionTemplate {
+      inputs: &[(2, 1, 0), (2, 0, 0)],
+      witnesses: vec![
+        Witness::new(),
+        inscription_with_parent("text/plain;charset=utf-8", "child", parent_inscription).to_witness(),
+      ],
+      ..Default::default()
+    });
+    let child_inscription = InscriptionId {
+      txid: child_txid,
+      index: 1,
+    };
+
+    bitcoin_rpc_server.mine_blocks(1);
+
+    let server = TestServer::new_with_bitcoin_rpc_server(bitcoin_rpc_server);
+
+    server.assert_response_csp(
+      format!("/preview/{}", child_inscription),
+      StatusCode::OK,
+      "default-src 'self'",
+      ".*<pre>child</pre>.*",
     );
   }
 }

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -773,7 +773,7 @@ impl Server {
     let json_result: Result<Value, serde_json::Error> = serde_json::from_slice(&inscription.body().unwrap());
     let json: Value = json_result.unwrap();
 
-    if !json.as_object().unwrap().contains_key("is_ord_pointer") {
+    if !json.as_object().unwrap().contains_key("use_p") {
       return None;
     }
 
@@ -793,7 +793,7 @@ impl Server {
   fn get_url_params_from_json_value(json: Value) -> String {
     let mut params_str = String::new();
 
-    if let Some(url_params_field) = json.get("url_params") {
+    if let Some(url_params_field) = json.get("params") {
       if let Some(url_params) = url_params_field.as_array() {
         let param_strs: Vec<&str> = url_params.into_iter().map(|v| v.as_str().unwrap()).collect();
         params_str = param_strs.join("&");
@@ -2596,7 +2596,7 @@ mod tests {
         Witness::new(),
         inscription_with_parent(
           "application/json",
-          "{\"is_ord_pointer\":1,\"url_params\":[\"tokenID=69\"]}",
+          "{\"use_p\":1,\"params\":[\"tokenID=69\"]}",
           parent_inscription
         ).to_witness()
       ],
@@ -2640,7 +2640,7 @@ mod tests {
         Witness::new(),
         inscription_with_parent(
           "application/json",
-          "{\"is_ord_pointer\":1}",
+          "{\"use_p\":1}",
           parent_inscription
         ).to_witness()
       ],


### PR DESCRIPTION
Why:
- Some generative art collections have inscribed all art within a single
parent inscription to save considerable storage space on the
blockchain.
- The ord explorer is unable to currently support collections inscribed
  in this manner.  This commit adds this support.

What:
- In order to support these generative art collections, we need to be able
  to inscribe the metadata for children in an agreed upon JSON spec.
- These child inscriptions are JSON documents containing url parameters
  that instruct the parent inscription to
  render a specific item in the collection.

How:
- Since all art is contained in the parent, we added a simple redirect to
  render the parent inscription with included url parameters.
- There are 3 constraints which must be in the child inscription before
  the redirect can happen:
1. The child inscription must have a parent inscription.
2. The child inscription's body data must be valid JSON.
3. The child inscription's body JSON data must contain a field named
   "use_p", with any value.

Proposed JSON standard:
```json
{
   "use_p": 1,
   "params": ["tokenID=4969"]
}
```

Related Issue:
- https://github.com/casey/ord/issues/783