### PR TITLE
fix inscribe_child core test

### DIFF
--- a/src/subcommand/wallet/inscribe.rs
+++ b/src/subcommand/wallet/inscribe.rs
@@ -107,7 +107,7 @@ impl Inscribe {
       .map(Ok)
       .unwrap_or_else(|| get_change_address(&client))?;
 
-    let (unsigned_commit_tx, partially_signed_reveal_tx, _recovery_key_pair) =
+    let (unsigned_commit_tx, partially_signed_reveal_tx, recovery_key_pair) =
       Inscribe::create_inscription_transactions(
         self.satpoint,
         parent,
@@ -147,9 +147,9 @@ impl Inscribe {
       return Ok(());
     }
 
-    // if !self.no_backup {
-    // Inscribe::backup_recovery_key(&client, recovery_key_pair, options.chain().network())?;
-    // }
+    if !self.no_backup {
+      Inscribe::backup_recovery_key(&client, recovery_key_pair, options.chain().network())?;
+    }
 
     let signed_raw_commit_tx = client
       .sign_raw_transaction_with_wallet(&unsigned_commit_tx, None, None)?
@@ -412,7 +412,7 @@ impl Inscribe {
     Ok((unsigned_commit_tx, reveal_tx, recovery_key_pair))
   }
 
-  fn _backup_recovery_key(
+  fn backup_recovery_key(
     client: &Client,
     recovery_key_pair: TweakedKeyPair,
     network: Network,

--- a/src/subcommand/wallet/inscribe.rs
+++ b/src/subcommand/wallet/inscribe.rs
@@ -466,18 +466,13 @@ impl Inscribe {
       let mut reveal_tx = reveal_tx.clone();
 
       for txin in &mut reveal_tx.input {
-        // only add dummy witness for reveal input/commit output
-        if txin.previous_output == OutPoint::null() {
-          txin.witness.push(
-            Signature::from_slice(&[0; SCHNORR_SIGNATURE_SIZE])
-              .unwrap()
-              .as_ref(),
-          );
-          txin.witness.push(script);
-          txin.witness.push(&control_block.serialize());
-        } else {
-          txin.witness = Witness::from_vec(vec![vec![0; SCHNORR_SIGNATURE_SIZE]]);
-        }
+        txin.witness.push(
+          Signature::from_slice(&[0; SCHNORR_SIGNATURE_SIZE])
+            .unwrap()
+            .as_ref(),
+        );
+        txin.witness.push(script);
+        txin.witness.push(&control_block.serialize());
       }
 
       fee_rate.fee(reveal_tx.vsize())

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -216,7 +216,6 @@ fn inscribe_child() {
   };
   let parent_id = output.inscription;
 
-  thread::sleep(Duration::from_secs(1));
   rpc_client.generate_to_address(1, &address).unwrap();
   thread::sleep(Duration::from_secs(1));
 

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -166,6 +166,8 @@ fn inscribe_child() {
     thread::sleep(Duration::from_millis(50));
   }
 
+  thread::sleep(Duration::from_secs(1));
+
   let _ = ord(&cookiefile, &ord_data_dir, rpc_port, &["wallet", "create"]);
 
   // get funds in wallet
@@ -178,6 +180,8 @@ fn inscribe_child() {
     bitcoincore_rpc::Auth::CookieFile(cookiefile.clone()),
   )
   .unwrap();
+
+  thread::sleep(Duration::from_secs(1));
 
   let address = rpc_client
     .get_new_address(None, Some(bitcoincore_rpc::json::AddressType::Bech32m))

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -1,5 +1,6 @@
 use {
   super::*,
+  bitcoin::Address,
   bitcoincore_rpc::{Client, RpcApi},
   std::ffi::OsString,
 };
@@ -187,7 +188,11 @@ fn inscribe_child() {
     .get_new_address(None, Some(bitcoincore_rpc::json::AddressType::Bech32m))
     .unwrap();
 
-  rpc_client.generate_to_address(101, &address).unwrap();
+  rpc_client.generate_to_address(1, &address).unwrap();
+
+  // to prevent the rescan from taking too long, mine 100 blocks to random address
+  let random_address = Address::from_str("bcrt1p998q5wmfjdwxkxpjcrnsfytdgu24qazas9gcjdfzl2asq9s38qtsgl8men").unwrap();
+  rpc_client.generate_to_address(100, &random_address).unwrap();
 
   fs::write(ord_data_dir.as_path().join("parent.txt"), "Pater").unwrap();
 

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -189,7 +189,6 @@ fn inscribe_child() {
     .unwrap();
 
   rpc_client.generate_to_address(1, &address).unwrap();
-
   // to prevent the rescan from taking too long, mine 100 blocks to random address
   let random_address = Address::from_str("bcrt1p998q5wmfjdwxkxpjcrnsfytdgu24qazas9gcjdfzl2asq9s38qtsgl8men").unwrap();
   rpc_client.generate_to_address(100, &random_address).unwrap();
@@ -198,11 +197,11 @@ fn inscribe_child() {
 
   #[derive(Deserialize, Debug)]
   struct Output {
-    _commit: String,
+    commit: String,
     inscription: String,
-    _parent: Option<String>,
-    _reveal: String,
-    _fees: u64,
+    parent: Option<String>,
+    reveal: String,
+    fees: u64,
   }
 
   let output: Output = match ord(
@@ -217,7 +216,9 @@ fn inscribe_child() {
   };
   let parent_id = output.inscription;
 
+  thread::sleep(Duration::from_secs(1));
   rpc_client.generate_to_address(1, &address).unwrap();
+  thread::sleep(Duration::from_secs(1));
 
   fs::write(ord_data_dir.as_path().join("child.txt"), "Filius").unwrap();
   let output: Output = match ord(


### PR DESCRIPTION
There seems to be an issue with `importdescriptors` which causes the test to timeout.  This method triggers a rescan of prior blocks, which causes the hangup.  This can be fixed by mining the bulk of the blocks to a random wallet address, and only mining a single block to the ord wallet address.  This speeds up the rescan, preventing the timeout.

https://github.com/casey/ord/pull/1963