### PR TITLE
Add recursive children metadata endpoint

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -90,6 +90,19 @@ pub struct ChildInscriptions {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct ChildMetadata {
+  pub id: InscriptionId,
+  pub metadata: Option<String>,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct ChildrenMetadata {
+  pub children: Vec<ChildMetadata>,
+  pub more: bool,
+  pub page: usize,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct ParentInscriptions {
   pub parents: Vec<RelativeInscriptionRecursive>,
   pub more: bool,

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -298,6 +298,14 @@ impl Server {
           "/r/children/{inscription_id}/inscriptions/{page}",
           get(r::children_inscriptions_paginated),
         )
+        .route(
+          "/r/children/{inscription_id}/metadata",
+          get(r::children_metadata),
+        )
+        .route(
+          "/r/children/{inscription_id}/metadata/{page}",
+          get(r::children_metadata_paginated),
+        )
         .route("/r/parents/{inscription_id}", get(r::parents))
         .route(
           "/r/parents/{inscription_id}/{page}",
@@ -7840,6 +7848,104 @@ next
 
     assert!(!child_inscriptions_json.more);
     assert_eq!(child_inscriptions_json.page, 1);
+  }
+
+  #[test]
+  fn child_metadata_recursive_endpoint() {
+    let server = TestServer::builder().chain(Chain::Regtest).build();
+    server.mine_blocks(1);
+
+    let parent_txid = server.core.broadcast_tx(TransactionTemplate {
+      inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
+      ..default()
+    });
+
+    let parent_inscription_id = InscriptionId {
+      txid: parent_txid,
+      index: 0,
+    };
+
+    server.assert_response(
+      format!("/r/children/{parent_inscription_id}/metadata"),
+      StatusCode::NOT_FOUND,
+      &format!("inscription {parent_inscription_id} not found"),
+    );
+
+    server.mine_blocks(1);
+
+    let child_metadata_json =
+      server.get_json::<api::ChildrenMetadata>(format!("/r/children/{parent_inscription_id}/metadata"));
+    assert_eq!(child_metadata_json.children.len(), 0);
+
+    let mut metadata = Vec::new();
+    ciborium::into_writer("child metadata", &mut metadata).unwrap();
+    let metadata_hex = hex::encode(&metadata);
+
+    let mut builder = script::Builder::new();
+    builder = Inscription {
+      content_type: Some("text/plain".into()),
+      body: Some("hello".into()),
+      metadata: Some(metadata),
+      parents: vec![parent_inscription_id.value()],
+      unrecognized_even_field: false,
+      ..default()
+    }
+    .append_reveal_script_to_builder(builder);
+
+    for _ in 0..110 {
+      builder = Inscription {
+        content_type: Some("text/plain".into()),
+        body: Some("hello".into()),
+        parents: vec![parent_inscription_id.value()],
+        unrecognized_even_field: false,
+        ..default()
+      }
+      .append_reveal_script_to_builder(builder);
+    }
+
+    let witness = Witness::from_slice(&[builder.into_bytes(), Vec::new()]);
+
+    let txid = server.core.broadcast_tx(TransactionTemplate {
+      inputs: &[(2, 0, 0, witness), (2, 1, 0, Default::default())],
+      ..default()
+    });
+
+    server.mine_blocks(1);
+
+    let first_child_inscription_id = InscriptionId { txid, index: 0 };
+    let hundredth_child_inscription_id = InscriptionId { txid, index: 99 };
+    let hundred_first_child_inscription_id = InscriptionId { txid, index: 100 };
+    let hundred_eleventh_child_inscription_id = InscriptionId { txid, index: 110 };
+
+    let child_metadata_json =
+      server.get_json::<api::ChildrenMetadata>(format!("/r/children/{parent_inscription_id}/metadata"));
+
+    assert_eq!(child_metadata_json.children.len(), 100);
+    assert_eq!(child_metadata_json.children[0].id, first_child_inscription_id);
+    assert_eq!(child_metadata_json.children[0].metadata, Some(metadata_hex));
+    assert_eq!(
+      child_metadata_json.children[99].id,
+      hundredth_child_inscription_id
+    );
+    assert_eq!(child_metadata_json.children[99].metadata, None);
+    assert!(child_metadata_json.more);
+    assert_eq!(child_metadata_json.page, 0);
+
+    let child_metadata_json = server
+      .get_json::<api::ChildrenMetadata>(format!("/r/children/{parent_inscription_id}/metadata/1"));
+
+    assert_eq!(child_metadata_json.children.len(), 11);
+    assert_eq!(
+      child_metadata_json.children[0].id,
+      hundred_first_child_inscription_id
+    );
+    assert_eq!(
+      child_metadata_json.children[10].id,
+      hundred_eleventh_child_inscription_id
+    );
+    assert_eq!(child_metadata_json.children[0].metadata, None);
+    assert!(!child_metadata_json.more);
+    assert_eq!(child_metadata_json.page, 1);
   }
 
   #[test]

--- a/src/subcommand/server/r.rs
+++ b/src/subcommand/server/r.rs
@@ -160,6 +160,13 @@ pub(super) async fn children_inscriptions(
   children_inscriptions_paginated(Extension(index), Path((inscription_id, 0))).await
 }
 
+pub(super) async fn children_metadata(
+  Extension(index): Extension<Arc<Index>>,
+  Path(inscription_id): Path<InscriptionId>,
+) -> ServerResult {
+  children_metadata_paginated(Extension(index), Path((inscription_id, 0))).await
+}
+
 pub(super) async fn children_inscriptions_paginated(
   Extension(index): Extension<Arc<Index>>,
   Path((parent, page)): Path<(InscriptionId, usize)>,
@@ -180,6 +187,61 @@ pub(super) async fn children_inscriptions_paginated(
 
     Ok(
       Json(api::ChildInscriptions {
+        children,
+        more,
+        page,
+      })
+      .into_response(),
+    )
+  })
+}
+
+pub(super) async fn children_metadata_paginated(
+  Extension(index): Extension<Arc<Index>>,
+  Path((parent, page)): Path<(InscriptionId, usize)>,
+) -> ServerResult {
+  task::block_in_place(|| {
+    let parent_sequence_number = index
+      .get_inscription_entry(parent)?
+      .ok_or_not_found(|| format!("inscription {parent}"))?
+      .sequence_number;
+
+    let (ids, more) =
+      index.get_children_by_sequence_number_paginated(parent_sequence_number, 100, page)?;
+
+    let mut parsed_inscriptions_by_txid = std::collections::BTreeMap::new();
+
+    for inscription_id in &ids {
+      if parsed_inscriptions_by_txid.contains_key(&inscription_id.txid) {
+        continue;
+      }
+
+      let transaction = index
+        .get_transaction(inscription_id.txid)?
+        .ok_or_not_found(|| format!("transaction {}", inscription_id.txid))?;
+
+      parsed_inscriptions_by_txid.insert(
+        inscription_id.txid,
+        ParsedEnvelope::from_transaction(&transaction),
+      );
+    }
+
+    let children = ids
+      .into_iter()
+      .map(|inscription_id| {
+        let parsed_inscriptions = parsed_inscriptions_by_txid
+          .get(&inscription_id.txid)
+          .ok_or_else(|| anyhow!("missing parsed inscription cache"))?;
+
+        Ok(api::ChildMetadata {
+          id: inscription_id,
+          metadata: get_metadata_hex(parsed_inscriptions, inscription_id),
+        })
+      })
+      .collect::<Result<Vec<api::ChildMetadata>>>()?;
+
+    Ok(
+      Json(api::ChildrenMetadata {
         children,
         more,
         page,
@@ -585,6 +647,13 @@ fn get_relative_inscription(
     satpoint,
     timestamp: timestamp(entry.timestamp.into()).timestamp(),
   })
+}
+
+fn get_metadata_hex(parsed_inscriptions: &[ParsedEnvelope], id: InscriptionId) -> Option<String> {
+  parsed_inscriptions
+    .get(id.index as usize)
+    .and_then(|parsed| parsed.payload.metadata.as_ref())
+    .map(hex::encode)
 }
 
 pub(super) async fn tx(


### PR DESCRIPTION
This adds a new recursive endpoint to fetch child inscription metadata in bulk: [/r/children/{inscription_id}/metadata](https://symmetrical-lamp-v4595qw4j4rfpj59.github.dev/) and [/r/children/{inscription_id}/metadata/{page}](https://symmetrical-lamp-v4595qw4j4rfpj59.github.dev/). It keeps the existing children inscription endpoints unchanged, introduces typed API responses for paginated child metadata, and includes server tests for not-found, empty results, metadata present vs absent, and pagination behavior.